### PR TITLE
fix setup.py containing a wrong valid version specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,5 @@ setup(
         "Environment :: Console",
         "Topic :: Text Processing",
     ],
-    python_requires=">=3.6.*, <4",
+    python_requires=">=3.7,<4",
 )


### PR DESCRIPTION
I have been facing the following issue while trying to install it.

```bash
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in noahong setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.7.*'
      [end of output]
```

This PR aims at finishing the python 3.6 support drop as well as fixing this issue by replacing: `>=3.6.*` by `>=3.7` in `python_requires` section of the `setup.py` file.

Thanks for reviewing as always 🙏 